### PR TITLE
vectors should be compared with compare not <

### DIFF
--- a/src/cljs/app/vetd_app/buyers/pages/round_detail.cljs
+++ b/src/cljs/app/vetd_app/buyers/pages/round_detail.cljs
@@ -837,7 +837,7 @@
   (sort-by (juxt #(- 1 (or (:result %) 0.5))
                  #(:sort % 1)
                  (comp :pname :product))
-           < round-product))
+           compare round-product))
 
 (defn c-page []
   (let [org-id& (rf/subscribe [:org-id])


### PR DESCRIPTION
vectors should be compared with `compare` not `<`
Otherwise, they get treated as a single string.