### PR TITLE
remove ?ref=vetd from setting website display & hide url on company website

### DIFF
--- a/src/cljs/app/vetd_app/buyers/components.cljs
+++ b/src/cljs/app/vetd_app/buyers/components.cljs
@@ -745,7 +745,7 @@
      [:> ui/GridRow 
       [c-display-field 6 "Website"
        (when (has-data? (v-fn :vendor/website))
-         [c-external-link (v-fn :vendor/website)])]
+         [c-external-link (v-fn :vendor/website) "Company Website"])]
       [c-display-field 6 "Headquarters" (v-fn :vendor/headquarters)]]
      [:> ui/GridRow
       [c-display-field 6 "Funding Status" (v-fn :vendor/funding)]

--- a/src/cljs/app/vetd_app/common/pages/settings.cljs
+++ b/src/cljs/app/vetd_app/common/pages/settings.cljs
@@ -5,7 +5,8 @@
             [vetd-app.ui :as ui]
             [vetd-app.util :as util]
             [reagent.core :as r]
-            [re-frame.core :as rf]))
+            [re-frame.core :as rf]
+            [clojure.string :as s]))
 
 ;;;; Events
 (rf/reg-event-fx
@@ -357,7 +358,9 @@
            [cc/c-field {:label "Name"
                         :value oname}]
            [cc/c-field {:label "Website"
-                        :value url}]
+                        :value (-> url
+                                   (s/split #"\?ref=vetd")
+                                   (s/join))}]
            [c-org-members memberships id oname]])))))
 
 (defn c-page []


### PR DESCRIPTION
https://trello.com/c/JaFggVQC/488-show-website-link-text-instead-of-url

https://trello.com/c/wJ5mavgS/487-remove-refvetd-only-on-the-user-settings-page